### PR TITLE
Feature/populate home page imgs sa

### DIFF
--- a/src/Components/Home.js
+++ b/src/Components/Home.js
@@ -10,6 +10,7 @@ const GET_PETS = gql`
     getAllPets {
       id
       name
+      image
     }
   }
 `

--- a/src/Components/PetCard.js
+++ b/src/Components/PetCard.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import '../Styles/PetCard.scss';
 
-const PetCard = ({ id, name }) => {
+const PetCard = ({ id, name, image }) => {
   const linkStyle = {
     textDecoration: 'none',
     color: 'black',
@@ -10,7 +10,7 @@ const PetCard = ({ id, name }) => {
   return (
     <div className="pet-card">
       <Link style={linkStyle} to={`pet/${id}`}>
-        <img className="pet-image" src="https://images.unsplash.com/photo-1518020382113-a7e8fc38eac9?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=1617&q=80" alt="{name}"/>
+        <img className="pet-image" src={image} alt="{name}"/>
         <h3 className="pet-card-name">{name}</h3>
       </Link>
     </div>

--- a/src/Components/PetContainer.js
+++ b/src/Components/PetContainer.js
@@ -9,6 +9,7 @@ const PetContainer = ({ pets }) => {
       <PetCard
         id={pet.id}
         name={pet.name}
+        image={pet.image}
       />
     )
   });


### PR DESCRIPTION
### 1. What changed?
-An additional query key was added to the graphql query, so that the page could have the images from the api populate the front home page. Additionally, an additional prop was added to the pet card component so that the url could pass down to the img element.

### 2. Why is this change necessary?
- This change was necessary so that we would, after the user posts the animal they want to re-home, the home page needs to be able to show the picture that has been refetched from the API. So this change makes sure we are able to fetch data from the api, so that when we need to refetch from a mutation, we know that it'll automatically update the page with a new pet being available for adoption.

### 3. What changed technically that may impact others?
- Well, we are querying the images from the back-end, so we are hitting the back-end server to get the images, which might impact the back-end devs.

### 4. How do we test it?
- You can test it by clicking the link for the website, and then seeing the different images of the pets on the home page.
