### PR TITLE
Fix broken WireFrame link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In the future, we would want to:
 
 #### Project Links
 - [Project Board](https://github.com/orgs/2110CapstoneProject/projects/1)
-- [Wireframe](https://miro.com/app/board/uXjVODUlug4=/)
+- [Wireframe](https://miro.com/app/board/uXjVODUlug4=/?share_link_id=649653039923)
 
 #### AUTHORS:
 ##### Frontend Team


### PR DESCRIPTION
### 1. What changed?
- Updated the Wireframe link so that the Miro board could be viewed without signing in/making a Miro account

### 2. Why is this change necessary?
- So hiring managers/recruiters can view the Wireframe

### 3. What changed technically that may impact others?

### 4. How do we test it?
